### PR TITLE
Update hltevzw

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -24,8 +24,8 @@ PRODUCT_PACKAGES += \
     nfc_nci.pn54x.default
 
 PRODUCT_COPY_FILES += \
-    device/samsung/hltetmo/configs/security_nfc_profile.dat:system/etc/security_nfc_profile.dat \
-    device/samsung/hltetmo/configs/libnfc-nxp.conf:system/etc/libnfc-nxp.conf
+    device/samsung/hltevzw/configs/security_nfc_profile.dat:system/etc/security_nfc_profile.dat \
+    device/samsung/hltevzw/configs/libnfc-nxp.conf:system/etc/libnfc-nxp.conf
 
 # Overlays
 DEVICE_PACKAGE_OVERLAYS += $(LOCAL_PATH)/overlay

--- a/proprietary-files.txt
+++ b/proprietary-files.txt
@@ -1,7 +1,7 @@
 # GPS
 -app/com.qualcomm.location/com.qualcomm.location.apk
-bin/gsiff_daemon
 etc/permissions/com.qualcomm.location.xml
+lib/hw/flp.default.so
 lib/libloc_api_v02.so
 vendor/lib/libgeofence.so
 vendor/lib/libizat_core.so
@@ -23,11 +23,13 @@ vendor/lib/libqmi_cci.so
 vendor/lib/libqmi_client_qmux.so
 vendor/lib/libqmi_common_so.so
 vendor/lib/libqmi_csi.so
+vendor/lib/libqmi_csvt_srvc.so
 vendor/lib/libqmi_encdec.so
 vendor/lib/libqmiservices.so
 
 # Radio
 bin/efsks
+bin/ds_fmc_appd
 bin/ks
 bin/qcks
 bin/qmuxd
@@ -39,4 +41,7 @@ lib/libril.so
 lib/libsec-ril.so
 lib/libsecnativefeature.so
 lib/libsecril-client.so
+lib/libsec-ril.so
 vendor/lib/libril-qcril-hook-oem.so
+vendor/lib/libconfigdb.so
+vendor/lib/libxml.so

--- a/system.prop
+++ b/system.prop
@@ -1,3 +1,4 @@
 # Radio
 rild.libargs=-d /dev/smd0
 rild.libpath=/system/lib/libsec-ril.so
+ro.telephony.ril.config=newril


### PR DESCRIPTION
Copied over some hltespr commits (the major one updating the ril stack). This has stopped com.android.phone force closes and mobile network disconnects. The other change was simply using the hltevzw path instead of hltetmo for the nfc files.
